### PR TITLE
Fix wrong label when seconds rolls over to minutes

### DIFF
--- a/src/edu/wpi/zirconium/lettercraze/player/controllers/LevelScreenControllers.java
+++ b/src/edu/wpi/zirconium/lettercraze/player/controllers/LevelScreenControllers.java
@@ -38,6 +38,7 @@ public class LevelScreenControllers implements Initializable {
     @FXML private Rectangle wordPreviewBox;
 
     @FXML private Text time;
+    @FXML private Text timeLabel;
     @FXML private Text score;
     @FXML private Text wordsFound;
     @FXML private Text wordLabel;
@@ -62,7 +63,7 @@ public class LevelScreenControllers implements Initializable {
         time.textProperty().bind(TimeFormatter.forValue(currentRound.timeProperty()));
         time.setOnMouseClicked(_me -> currentRound.incrementTime());
         currentRound.timeProperty().greaterThan(60).addListener(
-            (_p, _o, value) -> wordLabel.setText(value ? "minutes" : "seconds"));
+            (_p, _o, value) -> timeLabel.setText(value ? "minutes" : "seconds"));
 
         Timer timeUpdater = new Timer(true);
         timeUpdater.schedule(new TimerTask() {

--- a/src/edu/wpi/zirconium/lettercraze/player/views/Level.fxml
+++ b/src/edu/wpi/zirconium/lettercraze/player/views/Level.fxml
@@ -71,7 +71,7 @@
                      <Font name="Josefin Sans Light" size="29.0" />
                   </font>
                </Text>
-               <Text text="seconds">
+               <Text fx:id="timeLabel" text="seconds">
                   <font>
                      <Font name="Open Sans" size="14.0" />
                   </font>


### PR DESCRIPTION
Fixes "words" turning into "minutes" when you spend over a minute in a level.

closes #41