### PR TITLE
Fixed Row/Column mixup in TileView

### DIFF
--- a/src/edu/wpi/zirconium/lettercraze/shared/views/TileView.java
+++ b/src/edu/wpi/zirconium/lettercraze/shared/views/TileView.java
@@ -31,8 +31,8 @@ public class TileView extends StackPane {
         getRectangle().widthProperty().bind(container.getSizedTileWidth());
         getRectangle().heightProperty().bind(container.getSizedTileHeight());
 
-        layoutXProperty().bind(container.getTileX(rowProperty()));
-        layoutYProperty().bind(container.getTileY(columnProperty()));
+        layoutXProperty().bind(container.getTileX(columnProperty()));
+        layoutYProperty().bind(container.getTileY(rowProperty()));
     }
 
     public void setPos(Point pos) {


### PR DESCRIPTION
Gravity now goes in the correct direction
I switched rowProperty and columnProperty in TileView.java lines 34 and
35